### PR TITLE
Add support for PyTorch 2.7

### DIFF
--- a/.github/workflows/python_build_wheel.yaml
+++ b/.github/workflows/python_build_wheel.yaml
@@ -37,6 +37,11 @@ jobs:
   upload_pypi:
     needs: [build_wheels]
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/torch-delaunay
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4.1.8
         with:
@@ -44,8 +49,6 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@v1.9.0
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}
-          # repository_url: https://test.pypi.org/legacy/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        # with:
+        #   repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python_unit_test.yaml
+++ b/.github/workflows/python_unit_test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout source code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "torch >= 2.5.0, < 2.6.0"
+  "torch >= 2.7.0, < 2.8.0"
 ]
 
 
@@ -72,7 +72,7 @@ requires = [
   "numpy >= 1.4.0, < 2.0.0",
   "pybind11 >= 2.0.0, < 3.0.0",
   "setuptools ~= 70.0.0",
-  "torch >= 2.5.0, < 2.6.0",
+  "torch >= 2.7.0, < 2.8.0",
   "typing-extensions >= 4.8.0",
   "wheel >= 0.43.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,8 @@ archs = ["AMD64"]
 archs = ["arm64"]
 [tool.cibuildwheel.linux]
 archs = ["aarch64", "x86_64"]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 repair-wheel-command = """\
     auditwheel repair --only-plat \
         --exclude libc10.so \

--- a/torch_delaunay/__init__.py
+++ b/torch_delaunay/__init__.py
@@ -1,3 +1,3 @@
 from typing import Final
 
-__version__: Final[str] = "1.1.0"
+__version__: Final[str] = "1.2.0"


### PR DESCRIPTION
This patch updates the release to PyPI through trusted publishers, and also bumps PyTorch dependency to 2.7.*